### PR TITLE
emails for development

### DIFF
--- a/project_name/project_name/settings/development.py
+++ b/project_name/project_name/settings/development.py
@@ -15,3 +15,5 @@ DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
     'SHOW_TEMPLATE_CONTEXT': True,
 }
+#Emails aren't send but displayed in console
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
Prevent sending emails for development. The email's info is displayed in console.
